### PR TITLE
feat: GET /admin/stats

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4,6 +4,9 @@ require('./src/db/connection');
 const app = express();
 const port = process.env.PORT || 3000;
 
+const cors = require('cors');
+app.use(cors());
+
 app.use(express.json());
 //Importar rutas
 const routes = require('./src/routes/index');

--- a/backend/src/config/jwt.js
+++ b/backend/src/config/jwt.js
@@ -4,7 +4,8 @@ require('dotenv').config();
 const generarToken = (usuario) => {
     return jwt.sign({
         id: usuario.id,
-        email: usuario.email
+        email: usuario.email,
+        role: usuario.role
     }, process.env.TOKEN_SECRET, { expiresIn: '1h' });
 }
 

--- a/backend/src/controllers/admin.controller.js
+++ b/backend/src/controllers/admin.controller.js
@@ -1,0 +1,14 @@
+const {getStats} = require('../services/admin.service');
+
+const getAdminStats = async (req, res) => {
+    try{
+        const result = await getStats();
+        res.status(200).json(result);
+    } catch(error){
+        res.status(400).json({message: error.message});
+    }
+}
+
+module.exports = {
+    getAdminStats
+}

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -4,6 +4,9 @@ const {registerUser, loginUser, getProfile} = require('../services/auth.service'
 const register = async(req , res) =>{
     try{
         const {name, email , password} = req.body;
+        if(!name || !email || !password){
+            return res.status(400).json({message: "Nombre, email y contraseña son requeridos"});
+        }
         const result = await registerUser(name, email , password);
         res.status(201).json(result);
     }
@@ -15,6 +18,9 @@ const register = async(req , res) =>{
 const login = async(req,res)=>{
     try{
         const {email,password}=req.body;
+        if(!email || !password){
+            return res.status(400).json({message: "Email y contraseña son requeridos"});
+        }
         const result = await loginUser(email,password);
         res.status(200).json(result);
     }

--- a/backend/src/controllers/task.controller.js
+++ b/backend/src/controllers/task.controller.js
@@ -1,27 +1,43 @@
-const {createNewTask, getAllTasks} = require('../services/task.service')
+const {createNewTask, getTasksFromUser, updateTasksByUserId} = require('../services/task.service')
 
 //Crear tarea
 const createTask = async(req, res)=>{
     try{
         const {title, description}= req.body;
-        const result = await createNewTask(title, description);
+        if(!title){
+            return res.status(400).json({message: "El título es requerido"});
+        }
+        const userId = req.user.id;
+        const result = await createNewTask(title, description, userId);
         res.status(201).json(result);
     } catch(error){
         res.status(400).json({message: error.message});
     }
 }
 
-//Obtener todas las tareas
-const getTasks = async(req, res)=>{
+//Obtener tareas del usuario autenticado
+const getTasksUser = async(req,res)=>{
     try{
-        const result = await getAllTasks();
+        const userId = req.user.id;
+        const result = await getTasksFromUser(userId);
         res.status(200).json(result);
     }catch(error){
         res.status(400).json({message: error.message});
     }
 }
 
+const updateTaskByUserId = async(req,res)=>{
+    try{
+        const userId = req.user.id; //Obtenemos el ID del usuario autenticado
+        const {taskId} = req.params;
+        const result = await updateTasksByUserId(userId, taskId);
+        res.status(200).json(result);
+    }catch(error){
+        res.status(400).json({message: error.message});
+    }
+}
 module.exports = {
     createTask,
-    getTasks
+    getTasksUser,
+    updateTaskByUserId
 }

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -1,14 +1,47 @@
-CREATE TABLE tasks(
-    id SERIAL PRIMARY KEY,
-    title VARCHAR(255) NOT NULL,
-    description TEXT,
-    status BOOLEAN DEFAULT FALSE,
-    created_at TIMESTAMP DEFAULT NOW()
-)
 
 CREATE TABLE users(
     id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
     email VARCHAR(255) UNIQUE NOT NULL,
-    hash_password VARCHAR(255) NOT NULL,
+    hash_password VARCHAR(255) NULL,
+    role VARCHAR(10) DEFAULT 'user',
+    is_blocked BOOLEAN DEFAULT FALSE,
+    google_id VARCHAR(255) NULL,
+    two_factor_secret VARCHAR(255) NULL,
+    two_factor_enabled BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT NOW()
-)
+);
+
+CREATE TABLE tasks(
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    status BOOLEAN DEFAULT FALSE,
+    reminder_at TIMESTAMP NULL,
+    reminder_sent BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE stickers(
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    emoji VARCHAR(10) NOT NULL,
+    required_tasks INTEGER NOT NULL
+);
+
+CREATE TABLE user_stickers(
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    sticker_id INTEGER REFERENCES stickers(id) ON DELETE CASCADE,
+    unlocked_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE notifications(
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    task_id INTEGER REFERENCES tasks(id) ON DELETE CASCADE,
+    message TEXT NOT NULL,
+    read BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW()
+);

--- a/backend/src/middlewares/admin.middleware.js
+++ b/backend/src/middlewares/admin.middleware.js
@@ -1,0 +1,19 @@
+
+const isAdmin = (req, res, next) => {
+
+    if(!req.user){
+        return res.status(401).json({
+            error:"Usuario no autenticado"
+        })
+    }
+    if(req.user.role === 'admin'){
+        next(); // El usuario es admin, continuar con la siguiente función de middleware o ruta
+    }else{
+        return res.status(403).json({
+            error:"Acceso denegado: se requiere rol de administrador"
+        })
+    }
+}
+module.exports = {
+    isAdmin
+}

--- a/backend/src/middlewares/auth.middleware.js
+++ b/backend/src/middlewares/auth.middleware.js
@@ -17,9 +17,10 @@ const verificarToken = (req, res, next) =>{
         req.user = verified; // Agregar información del usuario al objeto de solicitud
         next(); // Continuar con la siguiente función de middleware o ruta
     } catch(error){
-        res.status(400).json({ error: "Token no válido" });
+        res.status(401).json({ error: "Token no válido" });
     }
 }
+
 module.exports = {
     verificarToken
 }

--- a/backend/src/models/admin.model.js
+++ b/backend/src/models/admin.model.js
@@ -1,0 +1,25 @@
+const connection = require('../db/connection');
+
+const getAllUsers = async()=>{
+    const query = `
+    SELECT COUNT(*) FROM users;
+    `;
+    const result = await connection.query(query);
+    return result.rows;
+}
+
+const getTaskComplete = async () => {
+    const query = `SELECT COUNT(*) FROM tasks WHERE status = TRUE`;
+    const result = await connection.query(query);
+    return result.rows;
+}
+const getAllTasks = async()=> {
+    const result = await connection.query('SELECT COUNT(*) FROM tasks');
+    return result.rows;
+}
+
+module.exports = {
+    getAllUsers,
+    getTaskComplete,
+    getAllTasks
+}

--- a/backend/src/models/task.model.js
+++ b/backend/src/models/task.model.js
@@ -1,24 +1,44 @@
 const connection = require('../db/connection');
 
  //crear tarea
- const createTask = async(title,description) => {
+ const createTask = async(title,description, userId) => {
     const query = `
-    INSERT INTO tasks (title,description)
-    VALUES ($1,$2)
+    INSERT INTO tasks (title,description,user_id)
+    VALUES ($1,$2,$3)
     RETURNING *;
     `;
-    const values = [title,description];
+    const values = [title,description, userId];
     const result = await connection.query(query,values);
     return result.rows[0];
  };
 
- //obtener todas las tareas
- const getTasks = async()=> {
-    const result = await connection.query('SELECT * FROM tasks');
+ //obtener todas las tareas por usuario
+ const getTasks = async(userId)=> {
+    const result = await connection.query('SELECT * FROM tasks WHERE user_id = $1', [userId]);
     return result.rows;
  };
 
+ const getTaskByIdAndUserId = async(taskId, userId) =>{
+      const query = `
+      SELECT * FROM tasks WHERE user_id = $1 AND id = $2;
+      `;
+      const values = [userId, taskId];
+      const result = await connection.query(query,values);
+      return result.rows[0];
+ }
+
+  const updateTaskByIdAndUserId = async(taskId, userId, status) =>{
+      const query = `
+      UPDATE tasks SET status = $1 WHERE id = $2 AND user_id = $3 RETURNING *;
+      `;
+      const values = [status, taskId, userId];
+      const result = await connection.query(query,values);
+      return result.rows[0];
+ }
+
  module.exports = {
     createTask,
-    getTasks
+    getTasks,
+    getTaskByIdAndUserId,
+    updateTaskByIdAndUserId
  }

--- a/backend/src/models/user.model.js
+++ b/backend/src/models/user.model.js
@@ -3,7 +3,7 @@ const connection = require('../db/connection');
 
 const findUserByEmail = async (email) => {
     const query = `
-    SELECT*FROM users WHERE email = $1;
+    SELECT * FROM users WHERE email = $1;
     `;
     const values = [email];
     const result = await connection.query(query, values);

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const {getAdminStats} = require('../controllers/admin.controller');
+const {isAdmin} = require('../middlewares/admin.middleware');
+const {verificarToken} = require('../middlewares/auth.middleware');
+
+router.use(verificarToken); // Aplicar el middleware de autenticación a todas las rutas
+router.use(isAdmin); // Aplicar el middleware de verificación de administrador a todas las rutas
+
+//ruta estadisticas
+router.get('/stats', getAdminStats)
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -2,11 +2,15 @@ const express = require('express');
 const router = express.Router();
 const authRoutes = require('./auth.routes');
 const taskRoutes = require('./task.routes');
+const adminRoutes = require('./admin.routes');
 
 //Rutas de autenticación
 router.use('/auth', authRoutes);
 
 //Rutas de tareas
 router.use('/tasks', taskRoutes);
+
+//Rutas de administración
+router.use('/admin', adminRoutes);
 
 module.exports = router;

--- a/backend/src/routes/task.routes.js
+++ b/backend/src/routes/task.routes.js
@@ -1,18 +1,19 @@
 const express = require('express');
 const router = express.Router();
-const {createTask, getTasks} = require('../controllers/task.controller');
+const {createTask, getTasksUser, updateTaskByUserId} = require('../controllers/task.controller');
 const {verificarToken} = require('../middlewares/auth.middleware');
 
-const authMiddleware = verificarToken;
-
-router.use(authMiddleware); // Aplicar el middleware de autenticación a todas las rutas
+router.use(verificarToken); // Aplicar el middleware de autenticación a todas las rutas
 
 //Rutas de tareas
 
 //Crear tarea
 router.post('/create', createTask);
 
-//Obtener todas las tareas
-router.get('/all', getTasks);
+//Obtener tareas del usuario autenticado
+router.get('/mine', getTasksUser);
+
+//Actualizar tarea por usuario
+router.put('/mine/:taskId', updateTaskByUserId);
 
 module.exports = router;

--- a/backend/src/services/admin.service.js
+++ b/backend/src/services/admin.service.js
@@ -1,0 +1,19 @@
+const{getAllUsers, getTaskComplete, getAllTasks} = require('../models/admin.model');
+
+const getStats = async()=>{
+    const users = await getAllUsers();
+    const tasks = await getAllTasks();
+    const completedTasks = await getTaskComplete();
+    return{
+        message:"Estadísticas obtenidas exitosamente",
+        stats:{
+            total_users: parseInt(users[0].count),
+            total_tasks: parseInt(tasks[0].count),
+            completed_tasks: parseInt(completedTasks[0].count)
+        }
+    }
+}
+
+module.exports = {
+    getStats
+}

--- a/backend/src/services/task.service.js
+++ b/backend/src/services/task.service.js
@@ -1,21 +1,22 @@
-const { getTasks, createTask } = require("../models/task.model");
+const { getTasks, createTask, getTaskByIdAndUserId, updateTaskByIdAndUserId } = require("../models/task.model");
 
 //crear tarea
-const createNewTask = async (title, description)=>{
-    const task = await createTask(title,description);
+const createNewTask = async (title, description, userId)=>{
+    const task = await createTask(title,description, userId);
     return{
-        message:"Nueva tare creada exitosamente",
+        message:"Nueva tarea creada exitosamente",
         task:{
             id: task.id,
+            user_id: task.user_id,
             title: task.title,
             description: task.description
         }
     };
 }
 
-//obtener todas las tareas
-const getAllTasks = async()=>{
-    const tasks = await getTasks();
+//obtener todas las tareas de un usuario
+const getTasksFromUser = async(userId)=>{
+    const tasks = await getTasks(userId);
     return{
         message:"Tareas obtenidas exitosamente",
         tasks: tasks.map(task => ({
@@ -25,8 +26,25 @@ const getAllTasks = async()=>{
         }))
     };
 }
+const updateTasksByUserId = async(userId,taskId) =>{
+    const task = await getTaskByIdAndUserId(taskId, userId);
+    if(!task){
+        throw new Error("Tarea no encontrada para el usuario");
+    }
+    const updatedTask = await updateTaskByIdAndUserId(taskId, userId, !task.status);
+    return{
+        message:"Tarea actualizada exitosamente",
+        task: {
+            id: updatedTask.id,
+            title: updatedTask.title,
+            description: updatedTask.description,
+            status: updatedTask.status
+        }
+    };
+}
 
 module.exports = {
     createNewTask,
-    getAllTasks
+    getTasksFromUser,
+    updateTasksByUserId
 }


### PR DESCRIPTION
- Nuevo endpoint `GET /admin/stats` con conteo de usuarios, tareas totales y tareas completadas
- Middleware `isAdmin` para proteger rutas de administrador (diferencia 401 vs 403)
- Refactor de tareas: ahora se asocian al usuario que las crea y solo el dueño puede verlas/actualizarlas
- Validación de inputs en `register`, `login` y `createTask`
- Schema: orden de tablas corregido, FKs con sintaxis válida para PostgreSQL y `ON DELETE CASCADE` coherente
- CORS habilitado en el servidor